### PR TITLE
fix: use new TS API

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -429,7 +429,6 @@ class SemgrepAnalysis(BackgroundTaskThread):
         rest is kept the same.
         """
         tree = self.parser.parse(bytes(src, "utf8"))
-        # captures now returns a dict of capture name -> list of nodes
         captures = self.func_annot_query.captures(tree.root_node)
         src_list = list(src)
 

--- a/__init__.py
+++ b/__init__.py
@@ -429,13 +429,16 @@ class SemgrepAnalysis(BackgroundTaskThread):
         rest is kept the same.
         """
         tree = self.parser.parse(bytes(src, "utf8"))
+        # captures now returns a dict of capture name -> list of nodes
         captures = self.func_annot_query.captures(tree.root_node)
         src_list = list(src)
 
-        for node, _ in captures:
-            # replace each annotation with the empty string
-            for i in range(node.start_byte, node.end_byte):
-                src_list[i] = ""
+        # Process all nodes from all capture groups
+        for capture_list in captures.values():
+            for node in capture_list:
+                # replace each annotation with the empty string
+                for i in range(node.start_byte, node.end_byte):
+                    src_list[i] = ""
 
         # reconstruct source code from the list
         return "".join(src_list)

--- a/plugin.json
+++ b/plugin.json
@@ -1,12 +1,16 @@
 {
     "pluginmetadataversion": 2,
     "name": "semgrep-bn",
-    "version": "1.0",
+    "version": "1.0.1",
     "author": "Samman Palihapitiya",
-    "type": [ "helper" ],
+    "type": [
+        "helper"
+    ],
     "description": "Search code with Semgrep",
     "longdescription": "",
-    "api": [ "python3" ],
+    "api": [
+        "python3"
+    ],
     "platforms": [
         "Darwin",
         "Linux",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 emoji
 tree-sitter
+tree-sitter-c
 semgrep

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 emoji
-tree-sitter
-tree-sitter-c
+tree-sitter==0.23.2
+tree-sitter-c==0.23.4
 semgrep


### PR DESCRIPTION
Fixes #1 

TLDR: Keeping up with breaking tree-sitter changes is hard.

PS: Currently the plugin is broken and cannot be used. Alternatively, pin the `tree-sitter` package to `v0.21.3`